### PR TITLE
chore(deps): bump com.android.tools.build:gradle in /android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.3.2'
+        classpath 'com.android.tools.build:gradle:8.5.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }


### PR DESCRIPTION
Bumps com.android.tools.build:gradle from 8.3.2 to 8.5.2.

---
updated-dependencies:
- dependency-name: com.android.tools.build:gradle dependency-type: direct:production update-type: version-update:semver-minor ...